### PR TITLE
fix: resolve HTTP parameter when API uses a server URL with base path

### DIFF
--- a/providers/openapi/handler_test.go
+++ b/providers/openapi/handler_test.go
@@ -65,6 +65,26 @@ func TestResolveEndpoint(t *testing.T) {
 			},
 		},
 		{
+			name: "base path with parameters",
+			test: func(t *testing.T, h http.HandlerFunc, c *openapi.Config) {
+				c.Servers[0].Url = "http://localhost/root"
+				op := openapitest.NewOperation(
+					openapitest.WithOperationParam("bar", true),
+					openapitest.WithResponse(http.StatusOK,
+						openapitest.WithContent("application/json",
+							openapitest.NewContent()),
+					),
+				)
+				openapitest.AppendPath("/foo/{bar}", c, openapitest.WithOperation("get", op))
+
+				r := httptest.NewRequest("get", "http://localhost/root/foo/bar", nil)
+				r = r.WithContext(context.WithValue(r.Context(), "servicePath", "/root"))
+				rr := httptest.NewRecorder()
+				h(rr, r)
+				require.Equal(t, http.StatusOK, rr.Code)
+			},
+		},
+		{
 			// there is no official specification for trailing slash. For ease of use, mokapi considers it equivalent
 			name: "spec define suffix / but request does not",
 			test: func(t *testing.T, h http.HandlerFunc, c *openapi.Config) {

--- a/providers/openapi/request_body_test.go
+++ b/providers/openapi/request_body_test.go
@@ -3,8 +3,6 @@ package openapi_test
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
 	"mokapi/providers/openapi"
 	"mokapi/providers/openapi/openapitest"
 	"mokapi/providers/openapi/schema/schematest"
@@ -12,6 +10,9 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 type errReader int
@@ -263,7 +264,7 @@ func TestBodyFromRequest(t *testing.T) {
 				return r
 			},
 			test: func(t *testing.T, result *openapi.Body, err error) {
-				require.EqualError(t, err, "read request body failed: no matching content type for 'application/xml' defined")
+				require.EqualError(t, err, "Unsupported Content-Type: application/xml\nThis operation only accepts: application/json\nPlease set the Content-Type header to one of the supported types.")
 				require.Equal(t, "<root><foo>bar</foo></root>", result.Raw)
 			},
 		},


### PR DESCRIPTION
improve: error message for request body with mismatched content type