### PR TITLE
fix: imap idle writter with nil connection

### DIFF
--- a/imap/idle.go
+++ b/imap/idle.go
@@ -21,7 +21,7 @@ func (c *conn) handleIdle(tag string) error {
 	}
 
 	done := make(chan struct{})
-	err := c.handler.Idle(&idleWriter{}, done, c.ctx)
+	err := c.handler.Idle(newIdleWriter(c.tpc), done, c.ctx)
 	if err != nil {
 		return err
 	}
@@ -57,6 +57,10 @@ type idleWriter struct {
 	tpc *textproto.Conn
 }
 
+func newIdleWriter(tpc *textproto.Conn) *idleWriter {
+	return &idleWriter{tpc: tpc}
+}
+
 func (w *idleWriter) WriteNumMessages(n uint32) error {
 	return w.tpc.PrintfLine("* %v EXISTS", n)
 }
@@ -66,5 +70,5 @@ func (w *idleWriter) WriteMessageFlags(msn uint32, flags []Flag) error {
 }
 
 func (w *idleWriter) WriteExpunge(msn uint32) error {
-	return w.tpc.PrintfLine("%v EXPUNGE", msn)
+	return w.tpc.PrintfLine("* %v EXPUNGE", msn)
 }


### PR DESCRIPTION
There's an intermittent panic that occurs because an IDLE writer was registered with a `nil` `textproto.Conn`; when SMTP appends a message, `Folder.Append` notifies IDLE writers and `WriteNumMessages` dereferences `w.tpc`, causing a nil-pointer panic. It only fails sometimes because the notification depends on timing, if no IDLE session is active or the writer has already been removed, no call happens. The fix is to construct idleWriter with the active connection (`newIdleWriter(tpc *textproto.Conn)`) so updates write through the IMAP connection.

This pull request refactors the handling of the `idleWriter` in the IMAP IDLE implementation to improve code clarity and correctness. The main updates include introducing a constructor for `idleWriter`, updating its instantiation, and fixing the format of the EXPUNGE response.

Refactoring and correctness improvements:

* Added a `newIdleWriter` constructor function for `idleWriter` to encapsulate initialization logic and replaced the previous direct instantiation with this constructor in the `handleIdle` method. [[1]](diffhunk://#diff-448b7fe9c5699f5e0303e5eff9774de13adc2a6cc8493db0403a24afc4fb6e3dR60-R63) [[2]](diffhunk://#diff-448b7fe9c5699f5e0303e5eff9774de13adc2a6cc8493db0403a24afc4fb6e3dL24-R24)
* Corrected the IMAP EXPUNGE response format in `WriteExpunge` to include the required `*` prefix, ensuring compliance with the IMAP protocol.