### PR TITLE
Potential fix for code scanning alert no. 45: Potentially unsafe quoting

### DIFF
--- a/schema/json/parser/parser_object.go
+++ b/schema/json/parser/parser_object.go
@@ -10,6 +10,7 @@ import (
 	"regexp/syntax"
 	"sort"
 	"strings"
+	"strconv"
 )
 
 func (p *Parser) parseObject(data interface{}, s *schema.Schema, evaluated map[string]bool) (*sortedmap.LinkedHashMap[string, interface{}], error) {
@@ -386,7 +387,7 @@ func (p *Parser) ValidatePatternProperty(name string, value interface{}, pattern
 				msg = err.Error()
 			}
 			return false, &ErrorDetail{
-				Message: fmt.Sprintf("validate string '%s' with regex pattern '%s' failed: error parsing regex: %s", name, pattern, msg),
+				Message: fmt.Sprintf("validate string %s with regex pattern '%s' failed: error parsing regex: %s", strconv.Quote(name), pattern, msg),
 				Field:   pattern,
 			}
 		}


### PR DESCRIPTION
Potential fix for [https://github.com/marle3003/mokapi/security/code-scanning/45](https://github.com/marle3003/mokapi/security/code-scanning/45)

The safest way to fix this issue is to avoid interpolating untrusted data directly into single-quoted strings using `%s`. Instead, use `fmt.Sprintf("%q", ... )`, which escapes both single and double quotes as required, or sanitize the input specifically by escaping single quotes (`'` → `\'`), and, just as crucially, also escape backslashes first (`\` → `\\`). In Go, `strconv.Quote` is the idiomatic method for quoting strings safely; it produces a double-quoted, safely escaped literal.

The fix will be to update the single line where the error message string is created so that `name` is safely quoted, replacing `'%s'` (which is a single-quoted string) with `%q` (Go double-quoted and escaped), or using `strconv.Quote(name)`. We'll also add the necessary import for `"strconv"` in `schema/json/parser/parser_object.go`.

This addresses all variants since they flow through the same pattern of unsafely embedding a potentially untrusted string into a quoted context.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
