### PR TITLE
Potential fix for code scanning alert no. 50: Incorrect conversion between integer types

### DIFF
--- a/kafka/protocol.go
+++ b/kafka/protocol.go
@@ -190,8 +190,8 @@ func getTag(f reflect.StructField) kafkaTag {
 			case "nullable":
 				if len(kv) == 1 {
 					t.nullable = 0
-				} else if i, err := strconv.Atoi(kv[1]); err == nil {
-					t.nullable = int16(i)
+				} else if parsed, err := strconv.ParseInt(kv[1], 10, 16); err == nil {
+					t.nullable = int16(parsed)
 				}
 			}
 		}


### PR DESCRIPTION
Potential fix for [https://github.com/marle3003/mokapi/security/code-scanning/50](https://github.com/marle3003/mokapi/security/code-scanning/50)

We should guarantee that only values that fit within the int16 type are assigned to the struct field `t.nullable`. There are two idiomatic ways to do this in Go:
1. Parse as a 16-bit integer with `strconv.ParseInt(kv[1], 10, 16)`, then assign after checking error, or
2. Continue using `strconv.Atoi`, but add explicit bounds checks against `math.MinInt16` and `math.MaxInt16` before assignment.

Option 1 is the cleanest and most direct fix; it eliminates the risk of `int` being a wider type and avoids needing bounds checks. The code should extract the integer value as an int64, check for error, and then assign as int16.

Therefore, in `kafka/protocol.go`, lines 193–194 should be replaced so that instead of using `strconv.Atoi(kv[1])`, we use `strconv.ParseInt(kv[1], 10, 16)`; on success, assign as `int16(parsed)`. This preserves the code's logic and safety.

No new imports are required (strconv is already used).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
