### PR TITLE
fix(ldif): prevent yaml parser from parsing ldif files

### DIFF
--- a/config/dynamic/parse.go
+++ b/config/dynamic/parse.go
@@ -69,7 +69,7 @@ func parse(c *Config) (interface{}, error) {
 		result, err = parseYaml(b, result)
 	case ".json":
 		result, err = parseJson(b, result)
-	case ".lua", ".js", ".cjs", ".mjs", ".ts":
+	case ".lua", ".js", ".cjs", ".mjs", ".ts", ".ldif":
 		result = string(b)
 	default:
 		// try parse from JSON and YAML


### PR DESCRIPTION
When ldif files are used, the yaml parser tries to parse these files. That leads to memory usage up to ~1.2 GB for a 170 KB ldif file and over 8 GB for a 2.2 MB ldif file. 

With this simple fix, the yaml parser is prevented from parsing ldif files and the memory usage drops to ~12 MB for the 170 KB file and ~32 MB for the 2.2 MB file.