### PR TITLE
fix(ldap): ScopeWholeSubtree wasn't handled by serveSearch

### DIFF
--- a/providers/directory/search.go
+++ b/providers/directory/search.go
@@ -80,6 +80,10 @@ func (d *Directory) serveSearch(rw ldap.ResponseWriter, r *ldap.Request) {
 				if dn := strings.Join(parts[1:], ","); dn != msg.BaseDN {
 					continue
 				}
+			case ldap.ScopeWholeSubtree:
+				if !strings.HasSuffix(strings.ToLower(e.Dn), strings.ToLower(msg.BaseDN)) {
+					continue
+				}
 			}
 			if d.skip(&e, msg.BaseDN) {
 				continue


### PR DESCRIPTION
When Scope = 2 (WholeSubtree) the entries in the response should be scoped to only that subtree.

RFC 4511 Section 4.5.1.2 says:
> wholeSubtree: The scope is constrained to the entry named by baseObject and to all its subordinates.
