### PR TITLE
Potential fix for code scanning alert no. 65: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,9 @@ on:
     branches:
       - '**'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test


### PR DESCRIPTION
Potential fix for [https://github.com/marle3003/mokapi/security/code-scanning/65](https://github.com/marle3003/mokapi/security/code-scanning/65)

Add an explicit `permissions` block to the workflow (or specific job) to enforce least privilege for `GITHUB_TOKEN`.  
Best fix here: add workflow-level permissions right after the `on` block so all jobs inherit it unless overridden later.

For this workflow, `contents: read` is the minimal and appropriate baseline for checkout/build/test operations. No additional `GITHUB_TOKEN` write scopes are required by the shown steps.

**File to change:** `.github/workflows/build.yml`  
**Region:** after line 5 (after branch list), before `jobs:`.  
**Needed additions:** YAML `permissions` key with `contents: read`.  
No imports/dependencies/methods are applicable for GitHub Actions YAML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
