### PR TITLE
Potential fix for code scanning alert no. 63: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -4,9 +4,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
 
 jobs:
   pull-request:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -4,7 +4,9 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
 
 jobs:
   pull-request:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,9 @@ on:
         description: "The latest tag"
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build mokapi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,8 @@ on:
 
 permissions:
   contents: read
+  pages: write
+  id-token: write
 
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,9 +23,7 @@ on:
         type: string
 
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
 
 jobs:
   build:


### PR DESCRIPTION
Potential fix for [https://github.com/marle3003/mokapi/security/code-scanning/63](https://github.com/marle3003/mokapi/security/code-scanning/63)

Add an explicit top-level `permissions` block in `.github/workflows/test.yml` so all jobs inherit least-privilege token access unless overridden.  
Best minimal fix (without changing intended functionality) is to add:

```yml
permissions:
  contents: read
```

Place it at workflow root (after `on:` block and before `jobs:`). This satisfies CodeQL’s recommendation and is sufficient for `actions/checkout` usage in this workflow. No imports, methods, or external definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
